### PR TITLE
SlowQuery: Table not exist is valid, because ORM generator tool can fail.

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -151,7 +151,10 @@ final class Utils
 				}
 			}
 		} catch (DBALException $e) {
-			throw new \RuntimeException($e->getMessage(), $e->getCode(), $e);
+			$hashExist = false;
+			if (class_exists(Debugger::class)) {
+				Debugger::log($e);
+			}
 		}
 		if ($hashExist !== false) {
 			$cache[$hash] = true;


### PR DESCRIPTION
- bug fix
- BC break? no
